### PR TITLE
Обновлена версия league/oauth2-client

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -20,7 +20,7 @@
     "require": {
         "php": ">=5.6.0",
         "ext-json": "*",
-        "league/oauth2-client": "2.4.*"
+        "league/oauth2-client": "^2.5"
     },
     "require-dev": {
         "phpunit/phpunit": "~4.5"


### PR DESCRIPTION
начиная с версии 2.5 league/oauth2-client использует guzzle 7, что важно при использовании laravel 8.x