### PR TITLE
Update league/oauth2-client to fix deprecation warnings

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -20,7 +20,7 @@
     "require": {
         "php": ">=7.1 || >=8.0",
         "ext-json": "*",
-        "league/oauth2-client": "^2"
+        "league/oauth2-client": "^2.8"
     },
     "require-dev": {
         "phpunit/phpunit": "~4.5",

--- a/composer.json
+++ b/composer.json
@@ -18,9 +18,9 @@
         "amocrm"
     ],
     "require": {
-        "php": ">=7.0",
+        "php": ">=7.1 || >=8.0",
         "ext-json": "*",
-        "league/oauth2-client": "2.6.*"
+        "league/oauth2-client": "^2"
     },
     "require-dev": {
         "phpunit/phpunit": "~4.5",


### PR DESCRIPTION
With current version of vendor package and using php 8.4, following deprecation notices occures: 
```log
[11-Mar-2025 11:15:41 UTC] PHP Deprecated:  League\OAuth2\Client\Provider\AbstractProvider::authorize(): Implicitly marking parameter $redirectHandler as nullable is deprecated, the explicit nullable type must be used instead in /app/vendor/league/oauth2-client/src/Provider/AbstractProvider.php on line 402
```

This pr updates oauth2-client dependecy.

**Implicit change: min php version have to be bumped to 7.1** 
because package dropped 7.0 support https://github.com/thephpleague/oauth2-client?tab=readme-ov-file#requirements 
